### PR TITLE
refactor: use textContent for text updates

### DIFF
--- a/frontend/src/draw.js
+++ b/frontend/src/draw.js
@@ -67,7 +67,8 @@ function updateDisks(firstBidboard, secondBitboard) {
       }
     }
   }
-  document.getElementById("scores").innerHTML = `${firstScore}-${secondScore}`;
+  document.getElementById("scores").textContent =
+    `${firstScore}-${secondScore}`;
 }
 
 function updateDiskIsFirst(r, c, isFirst) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -39,7 +39,7 @@ document.querySelectorAll(".cell").forEach((cell) => {
   });
 });
 
-document.querySelector("#version").innerHTML = process.env.REVERSI_VERSION;
+document.querySelector("#version").textContent = process.env.REVERSI_VERSION;
 
 const sleep = (milliSeconds) =>
   new Promise((resolve) => setTimeout(resolve, milliSeconds));


### PR DESCRIPTION
## Summary
- replace innerHTML with textContent in draw.js and index.js

## Testing
- `npm test`
- `npm run check:format`


------
https://chatgpt.com/codex/tasks/task_e_68ba75d59908832baae6124710b5adad