### PR TITLE
ci: narrow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   test-and-build:
@@ -57,6 +55,10 @@ jobs:
           path: ./frontend/dist
 
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- limit global job permissions to contents: read
- grant pages and id-token writes only to deploy job

## Testing
- `cargo +nightly test`
- `npm install`
- `npm run check:format`
- `npm test`
- `npm run build` *(fails: Cannot resolve 'reversi-wasm')*


------
https://chatgpt.com/codex/tasks/task_e_68ba7722ddd8832bb42de41b9697b99d