### PR TITLE
ci: use npm ci for frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
           cargo build
           cargo test
           wasm-pack build
-      - name: npm install, build, and test
+      - name: npm ci, build, and test
         working-directory: ./frontend
         run: |
-          npm install
+          npm ci --ignore-scripts
           npm run check:format
           npm test
           npm run build


### PR DESCRIPTION
## Summary
- use `npm ci --ignore-scripts` in CI workflow

## Testing
- `cargo +nightly test`
- `wasm-pack build --no-opt`
- `npm ci --ignore-scripts`
- `npm run check:format`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba8182aad0832bab9049d35b82b132