### PR TITLE
ビルド: タグ未検出時でもフロントエンドが動作するよう修正し wasm-opt を無効化

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -39,7 +39,7 @@ features = [
 opt-level = "s"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+wasm-opt = false # Disable wasm-opt to avoid external Binaryen download failures / download dependency
 
 [[bench]]
 name = "board_bench"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -38,6 +38,9 @@ features = [
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [[bench]]
 name = "board_bench"
 harness = false

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "check:format": "prettier --check **/*.{js,html,css}",
     "format": "prettier --write **/*.{js,html,css}",
     "test": "echo \"INFO: no test specified\"",
-    "build": "export REVERSI_VERSION=$(git describe --tag) && vite build",
-    "start": "export REVERSI_VERSION=$(git describe --tag) && vite"
+    "build": "export REVERSI_VERSION=$(git describe --tags --always) && vite build",
+    "start": "export REVERSI_VERSION=$(git describe --tags --always) && vite"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Motivation
- フロントエンドのビルドで `git describe` がタグを見つけられない環境でも動作させるためにコマンドを堅牢化する必要があった。 
- `wasm-pack` 実行時に `binaryen` のダウンロードに失敗する環境向けに最適化ステップを無効化してビルドを安定化する目的があった。

### Description
- `frontend/package.json` の `build` と `start` スクリプトを `git describe --tags --always` を使うように変更してタグが無くてもバージョン文字列を確保するようにした。 
- `engine/Cargo.toml` に `package.metadata.wasm-pack.profile.release` の `wasm-opt = false` を追加して `wasm-opt` を無効化し、`wasm-pack` 実行時の外部ダウンロード依存を回避した。 

### Testing
- 実行した自動化コマンドは全て成功した: `npm run check:format` は成功（Prettier チェック通過）。
- `npm test` は `INFO: no test specified` を出力して想定どおり終了。 
- `wasm-pack build` は環境整備後に成功し、`/workspace/reversi/engine/pkg` に成果物が生成された。 
- `cargo test` は全ユニットテストが通過（複数のテスト群で合計すべて成功）。 
- `cargo clippy -- -D warnings` は警告なしで完了。 
- `npm run build`（フロントエンドビルド）は成功し `dist/` 配下のアセット生成を確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698872731fec832b8a516604c95cdb17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebAssembly build configuration settings in the release profile.
  * Modified build and start scripts' version retrieval mechanism to ensure version information is consistently captured during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->